### PR TITLE
#49: Fix release-droid complaints regarding the changelog

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,3 +1,11 @@
 # Changes
 
 * [0.1.0](changes_0.1.0.md)
+
+<!--- This MyST Parser Sphinx directive is necassary to keep Sphinx happy. We need list here all release letters again, because release droid and other scripts assume Markdown --->
+```{toctree}
+---
+hidden:
+---
+changes_0.1.0
+```

--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -1,7 +1,3 @@
----
-orphan: true
----
-
 # BucketFs Utils Python 0.1.0, released 2022-01-18
 Code name: Initial implementation
 
@@ -34,3 +30,9 @@ n/a
 ## Security
 
 n/a
+
+
+---
+orphan: true
+---
+

--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -31,8 +31,3 @@ This release provides a initial version of the BucketFS Utils Python. It allows 
 
 n/a
 
-
----
-orphan: true
----
-

--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -16,7 +16,7 @@ This release provides a initial version of the BucketFS Utils Python. It allows 
 
 ## Bug Fixes
 
-n/a
+  - #49: Fix release-droid complaints regarding the changelog
   
 ## Documentation
 


### PR DESCRIPTION
- Remove orphan marker from changes_0.1.0.md, because release-droid doesn't like it
- Fixed the Sphinx warning missing in toctree with a hidden toctree in changelog.md instead

Fixes #49 